### PR TITLE
Bugfixes/5 unsaved changes shown when closing add contact with nothing entered

### DIFF
--- a/ContactKeeper.UI.Tests/Utilities/EditContactManagerTests.cs
+++ b/ContactKeeper.UI.Tests/Utilities/EditContactManagerTests.cs
@@ -214,7 +214,21 @@ internal class EditContactManagerTests
     }
 
     [Test]
-    public void CheckForUnsavedChanges_WhenContactToCompareIsNull_ReturnsTrue()
+    public void CheckForUnsavedChanges_WhenContactToCompareIsNullAndContactInfoPropertiesAreEmpty_ReturnsFalse()
+    {
+        // Arrange
+        var contactInfo = new ContactInfo();
+        ContactVm? contactToCompare = null;
+
+        // Act
+        var result = contactManager.CheckForUnsavedChanges(contactInfo, contactToCompare);
+
+        // Assert
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void CheckForUnsavedChanges_WhenContactToCompareIsNullAndContactInfoPropertiesAreNotEmpty_ReturnsTrue()
     {
         // Arrange
         var contactInfo = AutoFaker.Generate<ContactInfo>();

--- a/ContactKeeper.UI/Utilities/EditContactManager.cs
+++ b/ContactKeeper.UI/Utilities/EditContactManager.cs
@@ -88,6 +88,22 @@ internal class EditContactManager(IContactService contactService, ILogger logger
     public bool CheckForUnsavedChanges(ContactInfo contactInfoToCheck, ContactVm? contactToCompare)
     {
         ArgumentNullException.ThrowIfNull(contactInfoToCheck, nameof(contactInfoToCheck));
-        return contactToCompare is null || !contactInfoToCheck.IsMatch(ContactMapper.Map(contactToCompare));
+
+        bool hasChanges;
+
+        // if it's a new contact, check if any of the fields are filled in
+        if (contactToCompare is null)
+        {
+            hasChanges = !string.IsNullOrEmpty(contactInfoToCheck.FirstName) 
+                || !string.IsNullOrEmpty(contactInfoToCheck.LastName)
+                || !string.IsNullOrEmpty(contactInfoToCheck.Phone)
+                || !string.IsNullOrEmpty(contactInfoToCheck.Email);
+        }
+        else
+        {
+            hasChanges = !contactInfoToCheck.IsMatch(ContactMapper.Map(contactToCompare));
+        }
+
+        return hasChanges;
     }
 }


### PR DESCRIPTION
## What?

I have adapted the `CheckForUnsavedChanges` method to check if any of the fields were filled out if a new contact is being created (case: `contactToCompare ` is null). Consequently, I have also adapted the corresponding unit test.

## Testing?

In the Contact Overview, click on 'Add', then don't fill out anything and directly click on 'Cancel'. 
- [x] No popup warning of unsaved changes should appear.

**Cross tests:**
 - [x] Click on 'Add', fill out any field and click on 'Cancel': Popup shows.
 - [x] Click on 'Edit', change any field and click on 'Cancel': Popup shows.
 - [x] Click on 'Edit', don't change any field and click on 'Cancel': Popup doesn't show.