### PR TITLE
Change AssemblyName of UI project to 'ContactKeeper'

### DIFF
--- a/ContactKeeper.UI/ContactKeeper.UI.csproj
+++ b/ContactKeeper.UI/ContactKeeper.UI.csproj
@@ -42,4 +42,8 @@
 	  <Resource Include="Resources\app-icon.ico" />
 	  <Resource Include="Resources\app-icon.svg" />
 	</ItemGroup>
+
+	<PropertyGroup>
+		<AssemblyName>ContactKeeper</AssemblyName>
+	</PropertyGroup>
 </Project>


### PR DESCRIPTION
## What?

I have changed the AssemblyName of the UI project to 'ContactKeeper', so that the published executable is named just that.

## Testing?

Check the names of the build artifacts. These should now be named 'ContactKeeper.exe'.