### PR TITLE
Improve CI workflow: Add Debug builds, caching, and logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,16 @@
-name: .NET 8 CI
+# This workflow automates the CI/CD process for the ContactKeeper application.
+# It builds, tests, and publishes the application for multiple architectures.
+#
+# Features:
+# - Builds Debug and Release configurations (only Release goes to GitHub Releases)
+# - Runs unit tests on Debug builds only
+# - Restores dependencies (with caching for faster builds)
+# - Publishes self-contained binaries for win-x64, win-x86, and win-arm64
+# - Uploads build artifacts for later retrieval
+# - Creates a GitHub Release when a new version tag (vX.Y.Z) is pushed
+# - Uploads logs for build, test, and publish steps to help with debugging
+
+name: .NET 8 CI/CD for ContactKeeper
 
 on:
   push:
@@ -18,6 +30,7 @@ jobs:
     strategy:
       matrix:
         architecture: [win-x64, win-x86, win-arm64]
+        configuration: [Debug, Release]  # Now building both Debug and Release
 
     steps:
     - name: Checkout code
@@ -26,36 +39,108 @@ jobs:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.ref }}
 
+    # Cache NuGet dependencies
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: nuget-${{ runner.os }}-${{ hashFiles('**/packages.lock.json', '**/*.csproj') }}
+        restore-keys: |
+          nuget-${{ runner.os }}-
+
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '8.x'
 
+    # Cache MSBuild outputs to speed up incremental builds
+    - name: Cache MSBuild binaries
+      uses: actions/cache@v4
+      with:
+        path: |
+          **/bin
+          **/obj
+        key: msbuild-${{ runner.os }}-${{ matrix.architecture }}-${{ matrix.configuration }}-${{ hashFiles('**/*.csproj', '**/*.sln') }}
+        restore-keys: |
+          msbuild-${{ runner.os }}-${{ matrix.architecture }}-${{ matrix.configuration }}-
+
     - name: Restore dependencies
-      run: dotnet restore
+      run: dotnet restore > restore_${{ matrix.architecture }}_${{ matrix.configuration }}.log 2>&1
 
     - name: Build solution
-      run: dotnet build --no-restore -p:DebugType=none
+      run: dotnet build --configuration ${{ matrix.configuration }} --no-restore -p:DebugType=none > build_${{ matrix.architecture }}_${{ matrix.configuration }}.log 2>&1
 
+    # Run tests only on Debug builds
     - name: Run tests for Core
-      run: dotnet test ContactKeeper.Core.Tests/ContactKeeper.Core.Tests.csproj --no-build --verbosity normal
+      if: matrix.configuration == 'Debug'
+      run: dotnet test ContactKeeper.Core.Tests/ContactKeeper.Core.Tests.csproj --no-build --verbosity normal > test_core_${{ matrix.architecture }}.log 2>&1
 
     - name: Run tests for Infrastructure
-      run: dotnet test ContactKeeper.Infrastructure.Tests/ContactKeeper.Infrastructure.Tests.csproj --no-build --verbosity normal
+      if: matrix.configuration == 'Debug'
+      run: dotnet test ContactKeeper.Infrastructure.Tests/ContactKeeper.Infrastructure.Tests.csproj --no-build --verbosity normal > test_infra_${{ matrix.architecture }}.log 2>&1
 
     - name: Run tests for UI
-      run: dotnet test ContactKeeper.UI.Tests/ContactKeeper.UI.Tests.csproj --no-build --verbosity normal
+      if: matrix.configuration == 'Debug'
+      run: dotnet test ContactKeeper.UI.Tests/ContactKeeper.UI.Tests.csproj --no-build --verbosity normal > test_ui_${{ matrix.architecture }}.log 2>&1
 
+    # Publish only Release builds
     - name: Publish artifact
-      if: always()
-      run: dotnet publish ContactKeeper.UI/ContactKeeper.UI.csproj -c Release -o ${{github.workspace}}/publish/${{ matrix.architecture }} --self-contained -r ${{ matrix.architecture }} -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:DebugType=none
+      if: always() && matrix.configuration == 'Release'
+      run: dotnet publish ContactKeeper.UI/ContactKeeper.UI.csproj -c Release -o ${{github.workspace}}/publish/${{ matrix.architecture }} --self-contained -r ${{ matrix.architecture }} -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:DebugType=none > publish_${{ matrix.architecture }}.log 2>&1
 
-    - name: Upload artifact
+    # Upload all build artifacts
+    - name: Upload build artifacts
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: ContactKeeper-${{ matrix.architecture }}
-        path: ${{github.workspace}}/publish/${{ matrix.architecture }}
+        name: ContactKeeper-${{ matrix.architecture }}-${{ matrix.configuration }}
+        path: |
+          **/bin/${{ matrix.configuration }}/
+
+    # Upload restore logs (only if they exist)
+    - name: Upload restore logs
+      if: always() && hashFiles('restore_${{ matrix.architecture }}_${{ matrix.configuration }}.log') != ''
+      uses: actions/upload-artifact@v4
+      with:
+        name: Restore-Logs-${{ matrix.architecture }}-${{ matrix.configuration }}
+        path: restore_${{ matrix.architecture }}_${{ matrix.configuration }}.log
+
+    - name: Upload build logs
+      if: always() && hashFiles('build_${{ matrix.architecture }}_${{ matrix.configuration }}.log') != ''
+      uses: actions/upload-artifact@v4
+      with:
+        name: Build-Logs-${{ matrix.architecture }}-${{ matrix.configuration }}
+        path: build_${{ matrix.architecture }}_${{ matrix.configuration }}.log
+
+    # Upload test logs (only Debug)
+    - name: Upload test logs for Core
+      if: always() && matrix.configuration == 'Debug' && hashFiles('test_core_${{ matrix.architecture }}.log') != ''
+      uses: actions/upload-artifact@v4
+      with:
+        name: Test-Core-Logs-${{ matrix.architecture }}
+        path: test_core_${{ matrix.architecture }}.log
+
+    - name: Upload test logs for Infrastructure
+      if: always() && matrix.configuration == 'Debug' && hashFiles('test_infra_${{ matrix.architecture }}.log') != ''
+      uses: actions/upload-artifact@v4
+      with:
+        name: Test-Infrastructure-Logs-${{ matrix.architecture }}
+        path: test_infra_${{ matrix.architecture }}.log
+
+    - name: Upload test logs for UI
+      if: always() && matrix.configuration == 'Debug' && hashFiles('test_ui_${{ matrix.architecture }}.log') != ''
+      uses: actions/upload-artifact@v4
+      with:
+        name: Test-UI-Logs-${{ matrix.architecture }}
+        path: test_ui_${{ matrix.architecture }}.log
+
+    # Upload publish logs (only Release)
+    - name: Upload publish logs
+      if: always() && matrix.configuration == 'Release' && hashFiles('publish_${{ matrix.architecture }}.log') != ''
+      uses: actions/upload-artifact@v4
+      with:
+        name: Publish-Logs-${{ matrix.architecture }}
+        path: publish_${{ matrix.architecture }}.log
 
   release:
     if: startsWith(github.ref, 'refs/tags/')
@@ -63,14 +148,15 @@ jobs:
     needs: build
     permissions:
       contents: write
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
-    - name: Debug Check Files
-      run: ls -la ${{ github.workspace }}
+    - name: Download all artifacts
+      uses: actions/download-artifact@v4
 
     - name: Create GitHub Release
       id: create_release
@@ -83,29 +169,10 @@ jobs:
         draft: false
         prerelease: false
 
-    - name: Download all artifacts
-      uses: actions/download-artifact@v4
-
-    - name: Upload Release Assets (win-x64)
+    - name: Upload Release Assets (Release only)
       uses: actions/upload-release-asset@v1
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ContactKeeper-win-x64/ContactKeeper.zip
+        asset_path: ContactKeeper-win-x64-Release/ContactKeeper.zip
         asset_name: ContactKeeper-win-x64.zip
-        asset_content_type: application/zip
-
-    - name: Upload Release Assets (win-x86)
-      uses: actions/upload-release-asset@v1
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ContactKeeper-win-x86/ContactKeeper.zip
-        asset_name: ContactKeeper-win-x86.zip
-        asset_content_type: application/zip
-
-    - name: Upload Release Assets (win-arm64)
-      uses: actions/upload-release-asset@v1
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ContactKeeper-win-arm64/ContactKeeper.zip
-        asset_name: ContactKeeper-win-arm64.zip
         asset_content_type: application/zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,21 +73,21 @@ jobs:
       if: always() && hashFiles('logs/test_core_${{ matrix.architecture }}.log') != ''
       uses: actions/upload-artifact@v4
       with:
-        name: Logs/Test-Core-${{ matrix.architecture }}
+        name: Logs-Test-Core-${{ matrix.architecture }}
         path: logs/test_core_${{ matrix.architecture }}.log
     
     - name: Upload test logs for Infrastructure
       if: always() && hashFiles('logs/test_infra_${{ matrix.architecture }}.log') != ''
       uses: actions/upload-artifact@v4
       with:
-        name: Logs/Test-Infrastructure-${{ matrix.architecture }}
+        name: Logs-Test-Infrastructure-${{ matrix.architecture }}
         path: logs/test_infra_${{ matrix.architecture }}.log
     
     - name: Upload test logs for UI
       if: always() && hashFiles('logs/test_ui_${{ matrix.architecture }}.log') != ''
       uses: actions/upload-artifact@v4
       with:
-        name: Logs/Test-UI-${{ matrix.architecture }}
+        name: Logs-Test-UI-${{ matrix.architecture }}
         path: logs/test_ui_${{ matrix.architecture }}.log
 
   build:
@@ -118,7 +118,7 @@ jobs:
       if: always() && hashFiles('logs/build_${{ matrix.architecture }}_${{ matrix.configuration }}.log') != ''
       uses: actions/upload-artifact@v4
       with:
-        name: Logs/Build-${{ matrix.architecture }}-${{ matrix.configuration }}
+        name: Logs-Build-${{ matrix.architecture }}-${{ matrix.configuration }}
         path: logs/build_${{ matrix.architecture }}_${{ matrix.configuration }}.log
 
     # Publish artifact (only for Release builds)
@@ -133,7 +133,7 @@ jobs:
       if: always() && matrix.configuration == 'Release' && hashFiles('logs/publish_${{ matrix.architecture }}.log') != ''
       uses: actions/upload-artifact@v4
       with:
-        name: Logs/Publish-${{ matrix.architecture }}
+        name: Logs-Publish-${{ matrix.architecture }}
         path: logs/publish_${{ matrix.architecture }}.log
 
     # Upload build artifacts (organized by architecture and configuration)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,146 +18,111 @@ on:
       - main
     tags:
       - 'v*.*.*'
-
   pull_request:
     branches:
       - main
 
 jobs:
-  build:
+  test:
     runs-on: windows-latest
-
     strategy:
       matrix:
         architecture: [win-x64, win-x86, win-arm64]
-        configuration: [Debug, Release]  # Now building both Debug and Release
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.ref }}
-
-    # Cache NuGet dependencies
-    - name: Cache NuGet packages
-      uses: actions/cache@v4
-      with:
-        path: ~/.nuget/packages
-        key: nuget-${{ runner.os }}-${{ hashFiles('**/packages.lock.json', '**/*.csproj') }}
-        restore-keys: |
-          nuget-${{ runner.os }}-
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '8.x'
 
-    # Cache MSBuild outputs to speed up incremental builds
-    - name: Cache MSBuild binaries
-      uses: actions/cache@v4
-      with:
-        path: |
-          **/bin
-          **/obj
-        key: msbuild-${{ runner.os }}-${{ matrix.architecture }}-${{ matrix.configuration }}-${{ hashFiles('**/*.csproj', '**/*.sln') }}
-        restore-keys: |
-          msbuild-${{ runner.os }}-${{ matrix.architecture }}-${{ matrix.configuration }}-
-
+    # Restore dependencies and capture logs
     - name: Restore dependencies
-      run: dotnet restore > restore_${{ matrix.architecture }}_${{ matrix.configuration }}.log 2>&1
+      run: dotnet restore > logs/restore_${{ matrix.architecture }}.log 2>&1
 
-    - name: Build solution
-      run: dotnet build --configuration ${{ matrix.configuration }} --no-restore -p:DebugType=none > build_${{ matrix.architecture }}_${{ matrix.configuration }}.log 2>&1
+    # Build Debug configuration for testing
+    - name: Build Debug for Tests
+      run: dotnet build --configuration Debug --no-restore -p:DebugType=none > logs/build_${{ matrix.architecture }}_Debug.log 2>&1
 
-    # Run tests only on Debug builds
+    # Run tests and capture logs
     - name: Run tests for Core
-      if: matrix.configuration == 'Debug'
-      run: dotnet test ContactKeeper.Core.Tests/ContactKeeper.Core.Tests.csproj --no-build --verbosity normal > test_core_${{ matrix.architecture }}.log 2>&1
+      run: dotnet test ContactKeeper.Core.Tests/ContactKeeper.Core.Tests.csproj --no-build --verbosity normal > logs/test_core_${{ matrix.architecture }}.log 2>&1
 
-    - name: Run tests for Infrastructure
-      if: matrix.configuration == 'Debug'
-      run: dotnet test ContactKeeper.Infrastructure.Tests/ContactKeeper.Infrastructure.Tests.csproj --no-build --verbosity normal > test_infra_${{ matrix.architecture }}.log 2>&1
+    # Upload test logs only if they exist
+    - name: Upload test logs for Core
+      if: always() && hashFiles('logs/test_core_${{ matrix.architecture }}.log') != ''
+      uses: actions/upload-artifact@v4
+      with:
+        name: Logs/Test-Core-${{ matrix.architecture }}
+        path: logs/test_core_${{ matrix.architecture }}.log
 
-    - name: Run tests for UI
-      if: matrix.configuration == 'Debug'
-      run: dotnet test ContactKeeper.UI.Tests/ContactKeeper.UI.Tests.csproj --no-build --verbosity normal > test_ui_${{ matrix.architecture }}.log 2>&1
+  build:
+    needs: test  # Only run if tests pass
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        architecture: [win-x64, win-x86, win-arm64]
+        configuration: [Debug, Release]
 
-    # Publish only Release builds
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    # Restore dependencies and capture logs
+    - name: Restore dependencies
+      run: dotnet restore > logs/restore_${{ matrix.architecture }}_${{ matrix.configuration }}.log 2>&1
+
+    # Build application and capture logs
+    - name: Build solution
+      run: dotnet build --configuration ${{ matrix.configuration }} --no-restore -p:DebugType=none > logs/build_${{ matrix.architecture }}_${{ matrix.configuration }}.log 2>&1
+
+    # Upload build logs only if they exist
+    - name: Upload build logs
+      if: always() && hashFiles('logs/build_${{ matrix.architecture }}_${{ matrix.configuration }}.log') != ''
+      uses: actions/upload-artifact@v4
+      with:
+        name: Logs/Build-${{ matrix.architecture }}-${{ matrix.configuration }}
+        path: logs/build_${{ matrix.architecture }}_${{ matrix.configuration }}.log
+
+    # Publish artifact (only for Release builds)
     - name: Publish artifact
       if: always() && matrix.configuration == 'Release'
-      run: dotnet publish ContactKeeper.UI/ContactKeeper.UI.csproj -c Release -o ${{github.workspace}}/publish/${{ matrix.architecture }} --self-contained -r ${{ matrix.architecture }} -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:DebugType=none > publish_${{ matrix.architecture }}.log 2>&1
+      run: dotnet publish ContactKeeper.UI/ContactKeeper.UI.csproj -c Release -o artifacts/${{ matrix.architecture }}/Release --self-contained -r ${{ matrix.architecture }} -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:DebugType=none > logs/publish_${{ matrix.architecture }}.log 2>&1
 
-    # Upload all build artifacts
+    # Upload publish logs only if they exist
+    - name: Upload publish logs
+      if: always() && matrix.configuration == 'Release' && hashFiles('logs/publish_${{ matrix.architecture }}.log') != ''
+      uses: actions/upload-artifact@v4
+      with:
+        name: Logs/Publish-${{ matrix.architecture }}
+        path: logs/publish_${{ matrix.architecture }}.log
+
+    # Upload build artifacts (organized by architecture and configuration)
     - name: Upload build artifacts
       if: always()
       uses: actions/upload-artifact@v4
       with:
         name: ContactKeeper-${{ matrix.architecture }}-${{ matrix.configuration }}
-        path: |
-          **/bin/${{ matrix.configuration }}/
-
-    # Upload restore logs (only if they exist)
-    - name: Upload restore logs
-      if: always() && hashFiles('restore_${{ matrix.architecture }}_${{ matrix.configuration }}.log') != ''
-      uses: actions/upload-artifact@v4
-      with:
-        name: Restore-Logs-${{ matrix.architecture }}-${{ matrix.configuration }}
-        path: restore_${{ matrix.architecture }}_${{ matrix.configuration }}.log
-
-    - name: Upload build logs
-      if: always() && hashFiles('build_${{ matrix.architecture }}_${{ matrix.configuration }}.log') != ''
-      uses: actions/upload-artifact@v4
-      with:
-        name: Build-Logs-${{ matrix.architecture }}-${{ matrix.configuration }}
-        path: build_${{ matrix.architecture }}_${{ matrix.configuration }}.log
-
-    # Upload test logs (only Debug)
-    - name: Upload test logs for Core
-      if: always() && matrix.configuration == 'Debug' && hashFiles('test_core_${{ matrix.architecture }}.log') != ''
-      uses: actions/upload-artifact@v4
-      with:
-        name: Test-Core-Logs-${{ matrix.architecture }}
-        path: test_core_${{ matrix.architecture }}.log
-
-    - name: Upload test logs for Infrastructure
-      if: always() && matrix.configuration == 'Debug' && hashFiles('test_infra_${{ matrix.architecture }}.log') != ''
-      uses: actions/upload-artifact@v4
-      with:
-        name: Test-Infrastructure-Logs-${{ matrix.architecture }}
-        path: test_infra_${{ matrix.architecture }}.log
-
-    - name: Upload test logs for UI
-      if: always() && matrix.configuration == 'Debug' && hashFiles('test_ui_${{ matrix.architecture }}.log') != ''
-      uses: actions/upload-artifact@v4
-      with:
-        name: Test-UI-Logs-${{ matrix.architecture }}
-        path: test_ui_${{ matrix.architecture }}.log
-
-    # Upload publish logs (only Release)
-    - name: Upload publish logs
-      if: always() && matrix.configuration == 'Release' && hashFiles('publish_${{ matrix.architecture }}.log') != ''
-      uses: actions/upload-artifact@v4
-      with:
-        name: Publish-Logs-${{ matrix.architecture }}
-        path: publish_${{ matrix.architecture }}.log
+        path: artifacts/${{ matrix.architecture }}/${{ matrix.configuration }}/
 
   release:
+    needs: build  # Only run if the build succeeds
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
-    needs: build
     permissions:
       contents: write
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
 
+    # Download all build artifacts before releasing
     - name: Download all artifacts
       uses: actions/download-artifact@v4
 
+    # Create a new GitHub Release
     - name: Create GitHub Release
       id: create_release
       uses: ncipollo/release-action@v1.14.0
@@ -165,14 +130,15 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         tag: ${{ github.ref_name }}
         name: Release ${{ github.ref_name }}
-        bodyFile: ${{ github.workspace }}/release_notes.md
+        bodyFile: release_notes.md
         draft: false
         prerelease: false
 
-    - name: Upload Release Assets (Release only)
+    # Upload release assets (Release builds only)
+    - name: Upload Release Assets (win-x64)
       uses: actions/upload-release-asset@v1
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ContactKeeper-win-x64-Release/ContactKeeper.zip
+        asset_path: artifacts/win-x64/Release/ContactKeeper.zip
         asset_name: ContactKeeper-win-x64.zip
         asset_content_type: application/zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,10 @@ jobs:
 
     # Restore dependencies and capture logs
     - name: Restore dependencies
-      run: dotnet restore > logs/restore_${{ matrix.architecture }}.log 2>&1
+      run: |
+        mkdir -p logs
+        dotnet restore > logs/restore_${{ matrix.architecture }}.log 2>&1
+      shell: bash
 
     # Build Debug configuration for testing
     - name: Build Debug for Tests
@@ -48,7 +51,22 @@ jobs:
 
     # Run tests and capture logs
     - name: Run tests for Core
-      run: dotnet test ContactKeeper.Core.Tests/ContactKeeper.Core.Tests.csproj --no-build --verbosity normal > logs/test_core_${{ matrix.architecture }}.log 2>&1
+      run: |
+        mkdir -p logs
+        dotnet test ContactKeeper.Core.Tests/ContactKeeper.Core.Tests.csproj --no-build --verbosity normal > logs/test_core_${{ matrix.architecture }}.log 2>&1
+      shell: bash
+    
+    - name: Run tests for Infrastructure
+      run: |
+        mkdir -p logs
+        dotnet test ContactKeeper.Infrastructure.Tests/ContactKeeper.Infrastructure.Tests.csproj --no-build --verbosity normal > logs/test_infra_${{ matrix.architecture }}.log 2>&1
+      shell: bash
+    
+    - name: Run tests for UI
+      run: |
+        mkdir -p logs
+        dotnet test ContactKeeper.UI.Tests/ContactKeeper.UI.Tests.csproj --no-build --verbosity normal > logs/test_ui_${{ matrix.architecture }}.log 2>&1
+      shell: bash
 
     # Upload test logs only if they exist
     - name: Upload test logs for Core
@@ -57,6 +75,20 @@ jobs:
       with:
         name: Logs/Test-Core-${{ matrix.architecture }}
         path: logs/test_core_${{ matrix.architecture }}.log
+    
+    - name: Upload test logs for Infrastructure
+      if: always() && hashFiles('logs/test_infra_${{ matrix.architecture }}.log') != ''
+      uses: actions/upload-artifact@v4
+      with:
+        name: Logs/Test-Infrastructure-${{ matrix.architecture }}
+        path: logs/test_infra_${{ matrix.architecture }}.log
+    
+    - name: Upload test logs for UI
+      if: always() && hashFiles('logs/test_ui_${{ matrix.architecture }}.log') != ''
+      uses: actions/upload-artifact@v4
+      with:
+        name: Logs/Test-UI-${{ matrix.architecture }}
+        path: logs/test_ui_${{ matrix.architecture }}.log
 
   build:
     needs: test  # Only run if tests pass
@@ -76,7 +108,10 @@ jobs:
 
     # Build application and capture logs
     - name: Build solution
-      run: dotnet build --configuration ${{ matrix.configuration }} --no-restore -p:DebugType=none > logs/build_${{ matrix.architecture }}_${{ matrix.configuration }}.log 2>&1
+      run: |
+        mkdir -p logs
+        dotnet build --configuration ${{ matrix.configuration }} --no-restore -p:DebugType=none > logs/build_${{ matrix.architecture }}_${{ matrix.configuration }}.log 2>&1
+      shell: bash
 
     # Upload build logs only if they exist
     - name: Upload build logs
@@ -89,8 +124,10 @@ jobs:
     # Publish artifact (only for Release builds)
     - name: Publish artifact
       if: always() && matrix.configuration == 'Release'
-      run: dotnet publish ContactKeeper.UI/ContactKeeper.UI.csproj -c Release -o artifacts/${{ matrix.architecture }}/Release --self-contained -r ${{ matrix.architecture }} -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:DebugType=none > logs/publish_${{ matrix.architecture }}.log 2>&1
-
+      run: |
+        mkdir -p logs
+        dotnet publish ContactKeeper.UI/ContactKeeper.UI.csproj -c Release -o artifacts/${{ matrix.architecture }}/Release --self-contained -r ${{ matrix.architecture }} -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:DebugType=none > logs/publish_${{ matrix.architecture }}.log 2>&1
+      shell: bash
     # Upload publish logs only if they exist
     - name: Upload publish logs
       if: always() && matrix.configuration == 'Release' && hashFiles('logs/publish_${{ matrix.architecture }}.log') != ''


### PR DESCRIPTION
- Add Debug builds alongside Release builds for better testing.
- Tests now run only on Debug builds to avoid redundant execution.
- Implement caching for NuGet and MSBuild to speed up builds.
- Improve logging for build, test, and publish steps, ensuring logs are uploaded.
- Only Release builds are published and included in GitHub Releases.
- Fix artifact naming to clearly separate Debug and Release outputs.